### PR TITLE
Moved cdn to application layout html to fix load error

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,7 @@
   </nav>
 
   <body>
+    <script src="https://prod.flat-cdn.com/embed-js/v1.3.0/embed.min.js"></script>
     <% flash.each do |name, msg| -%>
       <%= content_tag :div, msg, class: name %>
     <% end -%>

--- a/app/views/scores/index.html.erb
+++ b/app/views/scores/index.html.erb
@@ -1,9 +1,7 @@
 <h1><%= @score.title %></h1>
 
 <div id="embed-container"></div>
-<%# <button id="export-xml" class="btn-cta-site">Submit Changes</button> %>
 <%= button_to 'Submit Changes', "/scores/#{@score.id}", method: :patch, id: 'export-xml' %>
-<script src="https://prod.flat-cdn.com/embed-js/v1.3.0/embed.min.js"></script>
 <script>
   var container = document.getElementById("embed-container");
   var embed = new Flat.Embed(container, {


### PR DESCRIPTION
## Description
This fixes the load error in the rendering of the editable editor

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes
Figured out that in rails when you're requiring a cdn, which is where the javascript is hosted, it needs to live in the application layout html page. Checked a bunch with local host and it seems to have fixed the problem.

## RSpec Results
```
.....................*...

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) As a registered user I can login
     # Temporarily skipped with xit
     # ./spec/features/user/user_login_spec.rb:4

Finished in 2.72 seconds (files took 3.74 seconds to load)
25 examples, 0 failures, 1 pending
```
