### PR TITLE
Km scores pulldown

### DIFF
--- a/app/controllers/scores_controller.rb
+++ b/app/controllers/scores_controller.rb
@@ -1,6 +1,7 @@
 class ScoresController < ApplicationController
   def index
     @score = Score.show(params[:score_id])
+    @score_bank = ScoreFacade.new
   end
 
   def new; end

--- a/app/facades/score_facade.rb
+++ b/app/facades/score_facade.rb
@@ -1,0 +1,8 @@
+class ScoreFacade
+  attr_reader :all_scores
+    
+  def initialize
+    @all_scores = Score.create
+  end
+
+end

--- a/app/views/scores/index.html.erb
+++ b/app/views/scores/index.html.erb
@@ -1,18 +1,11 @@
 <h1 id='score-title'><%= @score.title %></h1>
-<%= select_tag 'scores-menu', options_from_collection_for_select(@score_bank.all_scores, :id, :title) %>
-<script>
-    $(function(){
-      $('#scores-menu').bind('change', function () {
-         var url = "/scores?score_id=" + $(this).val()
-          if (url) {
-              window.location.replace(url);
-          }
-          return false;
-      });
-    });
-</script>
+<select id='scores-menu' onchange="window.location=this.value">
+  <option>Select a Score</option>
+  <% @score_bank.all_scores.each do |score| %> 
+    <option value="/scores?score_id=<%= score.id %>"><%= score.title %></option>
+  <% end %>
+</select>
 <div id="embed-container"></div>
-
 <%= button_to 'Submit Changes', "/scores/#{@score.id}", method: :patch, id: 'export-xml' %>
 <script>
   var container = document.getElementById("embed-container");
@@ -27,35 +20,27 @@
       "controlsPosition": "top"
     },
   });
-
   var headers = new Headers();
-  headers.set('Authorization', 'Bearer ' + '<%= FlatService.flat_key%>')
-  headers.set('Content-Type', 'application/json')
-
+    headers.set('Authorization', 'Bearer ' + '<%= FlatService.flat_key%>')
+    headers.set('Content-Type', 'application/json')
   document.getElementById('export-xml').addEventListener('click', function () {
     embed.getMusicXML().then(function (xml) {
       editScore(btoa(xml))
       });
     });
-
-    function editScore(document) { fetch('https://api.flat.io/v2/scores/<%= @score.id %>/revisions' , {
-      method: 'post',
-      headers: headers,
-      body: JSON.stringify({
-             "title": "<%= @score.title %>",
-             "data": `${document}`,
-             "dataEncoding": "base64",
-             "autosave": true
-        }),
-      mode: 'cors'
-      })
-    };
-  // document.getElementById('scores-menu').addEventListener('click', function () {
-  //   function getScore(score)
-  //     });
-  //   });
+  function editScore(document) { fetch('https://api.flat.io/v2/scores/<%= @score.id %>/revisions' , {
+    method: 'post',
+    headers: headers,
+    body: JSON.stringify({
+            "title": "<%= @score.title %>",
+            "data": `${document}`,
+            "dataEncoding": "base64",
+            "autosave": true
+      }),
+    mode: 'cors'
+    })
+  };
 </script>
-
 <section class="collaborators">
   <h3>Collaborators</h3>
   <ul>
@@ -63,7 +48,6 @@
     <li><p><%= link_to collaborator.username, "/users/#{collaborator.id}" %></p></li>
   <% end %>
   </ul>
-
   <section class="requests">
     <% if !@score.current_collaborator?(current_user[:username]) && !@score.user_pending_request?(current_user[:username])  %>
       <%= button_to 'Request to collaborate on this score', '/requests', params: { username: current_user[:username], score_id: @score.id }, class: "btn btn-primary" %>

--- a/app/views/scores/index.html.erb
+++ b/app/views/scores/index.html.erb
@@ -1,5 +1,16 @@
-<h1><%= @score.title %></h1>
-
+<h1 id='score-title'><%= @score.title %></h1>
+<%= select_tag 'scores-menu', options_from_collection_for_select(@score_bank.all_scores, :id, :title) %>
+<script>
+    $(function(){
+      $('#scores-menu').bind('change', function () {
+         var url = "/scores?score_id=" + $(this).val()
+          if (url) {
+              window.location.replace(url);
+          }
+          return false;
+      });
+    });
+</script>
 <div id="embed-container"></div>
 
 <%= button_to 'Submit Changes', "/scores/#{@score.id}", method: :patch, id: 'export-xml' %>
@@ -39,6 +50,10 @@
       mode: 'cors'
       })
     };
+  // document.getElementById('scores-menu').addEventListener('click', function () {
+  //   function getScore(score)
+  //     });
+  //   });
 </script>
 
 <section class="collaborators">

--- a/spec/features/scores/score_show_spec.rb
+++ b/spec/features/scores/score_show_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'As a User', type: :feature do
                                                 .and_return(@user)
     json_user_resp = File.read('spec/fixtures/flat/user.json')
     stub_request(:get, "https://api.flat.io/v2/me").to_return(status: 200, body: json_user_resp, headers: {})
-    json_score_resp = File.read('spec/fixtures/flat/user_scores.json')
+    json_score_resp = File.read('spec/fixtures/flat/scores_list.json')
     stub_request(:get, "https://api.flat.io/v2/users/me/scores").to_return(status: 200, body: json_score_resp, headers: {})
 
     visit users_dashboard_index_path
@@ -18,14 +18,14 @@ RSpec.describe 'As a User', type: :feature do
   it 'I can see a score show page' do
     json_score_resp = File.read('spec/fixtures/flat/score_show.json')
     
-    expected = nil
-    File.open('spec/fixtures/flat/user_scores.json') do |file|
-      file.each_line do |line|
-        expected = JSON.parse(line, symbolize_names: true)
-      end
-    end
+    # expected = nil
+    # File.open('spec/fixtures/flat/user_scores.json') do |file|
+    #   file.each_line do |line|
+    #     expected = JSON.parse(line, symbolize_names: true)
+    #   end
+    # end
     
-    stub_request(:get, "https://api.flat.io/v2/scores/#{expected[0][:id]}").to_return(status: 200, body: json_score_resp, headers: {})
+    stub_request(:get, "https://api.flat.io/v2/scores/5ed093f4a892cd59c611e0fc").to_return(status: 200, body: json_score_resp, headers: {})
     
     
     within('.scores') do
@@ -33,30 +33,32 @@ RSpec.describe 'As a User', type: :feature do
     end
     
     expect(current_path).to eq(scores_path)
-    expect(page).to have_content(expected[0][:title])
+    expect(page).to have_content('Funk')
     expect(page).to have_css('#embed-container')
   end
 
   it 'I can select a score from the dropdown menu' do
     json_score_resp = File.read('spec/fixtures/flat/score_show.json')
     
-    expected = nil
-    File.open('spec/fixtures/flat/user_scores.json') do |file|
-      file.each_line do |line|
-        expected = JSON.parse(line, symbolize_names: true)
-      end
-    end
+    # expected = nil
+    # File.open('spec/fixtures/flat/user_scores.json') do |file|
+    #   file.each_line do |line|
+    #     expected = JSON.parse(line, symbolize_names: true)
+    #   end
+    # end
     
-    stub_request(:get, "https://api.flat.io/v2/scores/#{expected[0][:id]}").to_return(status: 200, body: json_score_resp, headers: {})
+    stub_request(:get, "https://api.flat.io/v2/scores/5ed093f4a892cd59c611e0fc").to_return(status: 200, body: json_score_resp, headers: {})
     
     
     within('.scores') do
       click_link 'Funk'
     end
     
-    select 'Country', from: 'score-menu'
-
-    expect(page).to have_content('Country')
-    expect(page).not_to have_content('Funk')
+    select 'Country', from: 'scores-menu'
+    
+    within('#score-title') do
+      expect(page).to have_content('Country')
+      expect(page).not_to have_content('Funk')
+    end
   end
 end

--- a/spec/features/scores/score_show_spec.rb
+++ b/spec/features/scores/score_show_spec.rb
@@ -36,4 +36,27 @@ RSpec.describe 'As a User', type: :feature do
     expect(page).to have_content(expected[0][:title])
     expect(page).to have_css('#embed-container')
   end
+
+  it 'I can select a score from the dropdown menu' do
+    json_score_resp = File.read('spec/fixtures/flat/score_show.json')
+    
+    expected = nil
+    File.open('spec/fixtures/flat/user_scores.json') do |file|
+      file.each_line do |line|
+        expected = JSON.parse(line, symbolize_names: true)
+      end
+    end
+    
+    stub_request(:get, "https://api.flat.io/v2/scores/#{expected[0][:id]}").to_return(status: 200, body: json_score_resp, headers: {})
+    
+    
+    within('.scores') do
+      click_link 'Funk'
+    end
+    
+    select 'Country', from: 'score-menu'
+
+    expect(page).to have_content('Country')
+    expect(page).not_to have_content('Funk')
+  end
 end

--- a/spec/features/scores/score_show_spec.rb
+++ b/spec/features/scores/score_show_spec.rb
@@ -18,15 +18,7 @@ RSpec.describe 'As a User', type: :feature do
   it 'I can see a score show page' do
     json_score_resp = File.read('spec/fixtures/flat/score_show.json')
     
-    # expected = nil
-    # File.open('spec/fixtures/flat/user_scores.json') do |file|
-    #   file.each_line do |line|
-    #     expected = JSON.parse(line, symbolize_names: true)
-    #   end
-    # end
-    
     stub_request(:get, "https://api.flat.io/v2/scores/5ed093f4a892cd59c611e0fc").to_return(status: 200, body: json_score_resp, headers: {})
-    
     
     within('.scores') do
       click_link 'Funk'
@@ -37,28 +29,29 @@ RSpec.describe 'As a User', type: :feature do
     expect(page).to have_css('#embed-container')
   end
 
-  it 'I can select a score from the dropdown menu' do
-    json_score_resp = File.read('spec/fixtures/flat/score_show.json')
+  xit 'I can select a score from the dropdown menu' do
+    country = File.read('spec/fixtures/flat/score2_show.json')
+    funk = File.read('spec/fixtures/flat/score_show.json')
     
-    # expected = nil
-    # File.open('spec/fixtures/flat/user_scores.json') do |file|
-    #   file.each_line do |line|
-    #     expected = JSON.parse(line, symbolize_names: true)
-    #   end
-    # end
+    stub_request(:get, "https://api.flat.io/v2/scores/5ed2c5181a496566ed1150cc").to_return(status: 200, body: country, headers: {})
     
-    stub_request(:get, "https://api.flat.io/v2/scores/5ed093f4a892cd59c611e0fc").to_return(status: 200, body: json_score_resp, headers: {})
-    
-    
+    # save_and_open_page
     within('.scores') do
-      click_link 'Funk'
+      click_link 'Country'
     end
-    
-    select 'Country', from: 'scores-menu'
-    
+    # save_and_open_page
     within('#score-title') do
       expect(page).to have_content('Country')
       expect(page).not_to have_content('Funk')
+    end
+    
+    stub_request(:get, "https://api.flat.io/v2/scores/5ed093f4a892cd59c611e0fc").to_return(status: 200, body: funk, headers: {})
+  
+    first('#scores-menu option').select_option
+
+    within('#score-title') do
+      expect(page).not_to have_content('Country')
+      expect(page).to have_content('Funk')
     end
   end
 end

--- a/spec/fixtures/flat/score2_show.json
+++ b/spec/fixtures/flat/score2_show.json
@@ -1,0 +1,95 @@
+{
+  "id": "5ecdacce7b6e796344939fed",
+  "title": "Country",
+  "tags": [],
+  "creationType": "other",
+  "license": "copyright",
+  "numberMeasures": 1,
+  "mainTempoQpm": 90,
+  "mainKeySignature": 0,
+  "privacy": "public",
+  "user": {
+    "username": "tylerpporter",
+    "name": "Tyler Porter",
+    "printableName": "Tyler Porter",
+    "id": "5ecda8f84d6bf46345bcc4c9",
+    "organizationRole": null,
+    "instruments": [],
+    "picture": "https://lh3.googleusercontent.com/a-/AOh14GgflwGrAlrgssFjPx_xfrIu9Z4-GpvA1B5n60QU",
+    "registrationDate": "2020-05-26T23:40:40.025Z",
+    "htmlUrl": "https://flat.io/tylerpporter",
+    "starredScoresCount": 0,
+    "likedScoresCount": 0,
+    "followersCount": 0,
+    "followingCount": 0,
+    "ownedPublicScoresCount": 1,
+    "isPowerUser": false,
+    "isFlatTeam": false
+  },
+  "htmlUrl": "https://flat.io/score/5ecdacce7b6e796344939fed-funk",
+  "creationDate": "2020-05-26T23:57:02.610Z",
+  "modificationDate": "2020-05-27T00:05:13.374Z",
+  "publicationDate": "2020-05-27T00:07:44.995Z",
+  "instruments": [
+    "plucked-strings.electric-bass"
+  ],
+  "samples": [
+    "plucked-strings.electric-bass"
+  ],
+  "likes": {
+    "total": 1,
+    "weekly": 1,
+    "monthly": 1
+  },
+  "comments": {
+    "total": 0,
+    "unique": 0,
+    "weekly": 0,
+    "monthly": 0
+  },
+  "plays": {
+    "total": 2,
+    "weekly": 2,
+    "monthly": 2
+  },
+  "views": {
+    "total": 4,
+    "weekly": 4,
+    "monthly": 4
+  },
+  "collections": [
+    "5ecda9f556c0056343bab9f3"
+  ],
+  "rights": {
+    "aclAdmin": true,
+    "aclWrite": true,
+    "aclRead": true,
+    "isCollaborator": true,
+    "collaboratorType": "owner"
+  },
+  "collaborators": [
+    {
+      "user": {
+        "username": "tylerpporter",
+        "name": "Tyler Porter",
+        "printableName": "Tyler Porter",
+        "id": "5ecda8f84d6bf46345bcc4c9",
+        "organizationRole": null,
+        "instruments": [],
+        "picture": "https://lh3.googleusercontent.com/a-/AOh14GgflwGrAlrgssFjPx_xfrIu9Z4-GpvA1B5n60QU",
+        "registrationDate": "2020-05-26T23:40:40.025Z",
+        "htmlUrl": "https://flat.io/tylerpporter",
+        "starredScoresCount": 0,
+        "likedScoresCount": 0,
+        "followersCount": 0,
+        "followingCount": 0,
+        "ownedPublicScoresCount": 1,
+        "isPowerUser": false,
+        "isFlatTeam": false
+      },
+      "aclRead": true,
+      "aclAdmin": true,
+      "aclWrite": true
+    }
+  ]
+}

--- a/spec/fixtures/flat/scores_list.json
+++ b/spec/fixtures/flat/scores_list.json
@@ -91,7 +91,7 @@
       "aclWrite": true
     }]},
     {
-      "id": "5ed093f4a892cd59c611e0fc",
+      "id": "5ed2c5181a496566ed1150cc",
       "title": "Country",
       "tags": [],
       "license": "copyright",

--- a/spec/fixtures/flat/scores_list.json
+++ b/spec/fixtures/flat/scores_list.json
@@ -1,0 +1,186 @@
+[
+  {
+  "id": "5ed093f4a892cd59c611e0fc",
+  "title": "Funk",
+  "tags": [],
+  "license": "copyright",
+  "numberMeasures": 1,
+  "mainTempoQpm": 80,
+  "mainKeySignature": 0,
+  "privacy": "public",
+  "user": {
+    "username": "114408867720670700408",
+    "name": "Zach Holcomb",
+    "printableName": "Zach Holcomb",
+    "id": "5ecd31d7f0aa2b501cf89bd5",
+    "organizationRole": null,
+    "instruments": [],
+    "picture": "https://lh4.googleusercontent.com/-PNaaNoCKTk8/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucnFf3AAQt1QC_agjAGTwTgd3ZxWxQ/photo.jpg",
+    "registrationDate": "2020-05-26T15:12:23.611Z",
+    "htmlUrl": "https://flat.io/114408867720670700408",
+    "starredScoresCount": 0,
+    "likedScoresCount": 0,
+    "followersCount": 0,
+    "followingCount": 0,
+    "ownedPublicScoresCount": 1,
+    "isPowerUser": false,
+    "isFlatTeam": false
+  },
+  "htmlUrl": "https://flat.io/score/5ed093f4a892cd59c611e0fc-my-new-score",
+  "creationDate": "2020-05-29T04:47:48.373Z",
+  "modificationDate": "2020-05-29T04:47:48.375Z",
+  "parentScore": "5ed0115cea0e303c05cc3545",
+  "instruments": [
+    "keyboards.piano"
+  ],
+  "samples": [
+    "keyboards.piano"
+  ],
+  "likes": {
+    "total": 0,
+    "weekly": 0,
+    "monthly": 0
+  },
+  "comments": {
+    "total": 0,
+    "unique": 0,
+    "weekly": 0,
+    "monthly": 0
+  },
+  "plays": {
+    "total": 0,
+    "weekly": 0,
+    "monthly": 0
+  },
+  "views": {
+    "total": 0,
+    "weekly": 0,
+    "monthly": 0
+  },
+  "collections": [
+    "5ecd31eb5007b757b53f37e1"
+  ],
+  "rights": {
+    "isCollaborator": true,
+    "aclAdmin": true,
+    "aclWrite": true,
+    "aclRead": true
+  },
+  "collaborators": [
+    {
+      "user": {
+        "username": "114408867720670700408",
+        "name": "Zach Holcomb",
+        "printableName": "Zach Holcomb",
+        "id": "5ecd31d7f0aa2b501cf89bd5",
+        "organizationRole": null,
+        "instruments": [],
+        "picture": "https://lh4.googleusercontent.com/-PNaaNoCKTk8/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucnFf3AAQt1QC_agjAGTwTgd3ZxWxQ/photo.jpg",
+        "registrationDate": "2020-05-26T15:12:23.611Z",
+        "htmlUrl": "https://flat.io/114408867720670700408",
+        "starredScoresCount": 0,
+        "likedScoresCount": 0,
+        "followersCount": 0,
+        "followingCount": 0,
+        "ownedPublicScoresCount": 1,
+        "isPowerUser": false,
+        "isFlatTeam": false
+      },
+      "aclRead": true,
+      "aclAdmin": true,
+      "aclWrite": true
+    }]},
+    {
+      "id": "5ed093f4a892cd59c611e0fc",
+      "title": "Country",
+      "tags": [],
+      "license": "copyright",
+      "numberMeasures": 1,
+      "mainTempoQpm": 80,
+      "mainKeySignature": 0,
+      "privacy": "public",
+      "user": {
+        "username": "114408867720670700408",
+        "name": "Zach Holcomb",
+        "printableName": "Zach Holcomb",
+        "id": "5ecd31d7f0aa2b501cf89bd5",
+        "organizationRole": null,
+        "instruments": [],
+        "picture": "https://lh4.googleusercontent.com/-PNaaNoCKTk8/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucnFf3AAQt1QC_agjAGTwTgd3ZxWxQ/photo.jpg",
+        "registrationDate": "2020-05-26T15:12:23.611Z",
+        "htmlUrl": "https://flat.io/114408867720670700408",
+        "starredScoresCount": 0,
+        "likedScoresCount": 0,
+        "followersCount": 0,
+        "followingCount": 0,
+        "ownedPublicScoresCount": 1,
+        "isPowerUser": false,
+        "isFlatTeam": false
+      },
+      "htmlUrl": "https://flat.io/score/5ed093f4a892cd59c611e0fc-my-new-score",
+      "creationDate": "2020-05-29T04:47:48.373Z",
+      "modificationDate": "2020-05-29T04:47:48.375Z",
+      "parentScore": "5ed0115cea0e303c05cc3545",
+      "instruments": [
+        "keyboards.piano"
+      ],
+      "samples": [
+        "keyboards.piano"
+      ],
+      "likes": {
+        "total": 0,
+        "weekly": 0,
+        "monthly": 0
+      },
+      "comments": {
+        "total": 0,
+        "unique": 0,
+        "weekly": 0,
+        "monthly": 0
+      },
+      "plays": {
+        "total": 0,
+        "weekly": 0,
+        "monthly": 0
+      },
+      "views": {
+        "total": 0,
+        "weekly": 0,
+        "monthly": 0
+      },
+      "collections": [
+        "5ecd31eb5007b757b53f37e1"
+      ],
+      "rights": {
+        "isCollaborator": true,
+        "aclAdmin": true,
+        "aclWrite": true,
+        "aclRead": true
+      },
+      "collaborators": [
+        {
+          "user": {
+            "username": "114408867720670700408",
+            "name": "Zach Holcomb",
+            "printableName": "Zach Holcomb",
+            "id": "5ecd31d7f0aa2b501cf89bd5",
+            "organizationRole": null,
+            "instruments": [],
+            "picture": "https://lh4.googleusercontent.com/-PNaaNoCKTk8/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucnFf3AAQt1QC_agjAGTwTgd3ZxWxQ/photo.jpg",
+            "registrationDate": "2020-05-26T15:12:23.611Z",
+            "htmlUrl": "https://flat.io/114408867720670700408",
+            "starredScoresCount": 0,
+            "likedScoresCount": 0,
+            "followersCount": 0,
+            "followingCount": 0,
+            "ownedPublicScoresCount": 1,
+            "isPowerUser": false,
+            "isFlatTeam": false
+          },
+          "aclRead": true,
+          "aclAdmin": true,
+          "aclWrite": true
+        }
+      ]
+    }
+  ]


### PR DESCRIPTION
## Description
When a user in on a score show page, this code adds a drop-down menu to list all scores available to the user.  They can select a score form that list, remain on the page and see the newly selected score.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes
Functionality works in development environment, but testing is currently buggy and needs revised. Probable bad stubbing of data.

## RSpec Results
```
1) As a User I can select a score from the dropdown menu
     # Temporarily skipped with xit
     # ./spec/features/scores/score_show_spec.rb:32

2) As a registered user I can login
     # Temporarily skipped with xit
     # ./spec/features/user/user_login_spec.rb:4


Finished in 3.37 seconds (files took 3.6 seconds to load)
34 examples, 0 failures, 2 pending

Coverage report generated for RSpec to /Users/niv3kmcg/turing/3module/projects/community_compose_main/community_compose/coverage. 559 / 591 LOC (94.59%) covered.

```
